### PR TITLE
Only match command output end in last line (fixes #3)

### DIFF
--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -11,8 +11,8 @@ class Parser
     const EOL = "\r\n";
     const LEOL = 2;
 
-    const COMMAND_END = "\n--END COMMAND--";
-    const LCOMMAND_END = 16;
+    const COMMAND_END = "--END COMMAND--";
+    const LCOMMAND_END = 15;
 
     private $buffer = '';
     private $gotInitial = false;
@@ -40,9 +40,13 @@ class Parser
 
     private function parseMessage($message)
     {
+        $lines = explode(self::EOL, $message);
+        $last  = count($lines) - 1;
         $parts = array();
-        foreach (explode(self::EOL, $message) as $line) {
-            if (substr($line, -self::LCOMMAND_END) === self::COMMAND_END) {
+
+        foreach ($lines as $i => $line) {
+            $pos = strlen($line) - self::LCOMMAND_END - 1;
+            if ($i === $last && substr($line, -self::LCOMMAND_END) === self::COMMAND_END && ($pos < 0 || $line[$pos] === "\n")) {
                 $key = '_';
                 $value = $line;
             } else {

--- a/tests/Protocol/ParserTest.php
+++ b/tests/Protocol/ParserTest.php
@@ -50,6 +50,38 @@ class ParserTest extends TestCase
         $this->assertEquals("Testing: yes\nAnother Line\n--END COMMAND--", $first->getPart('_'));
     }
 
+    public function testParsingCommandResponseEmpty()
+    {
+        $parser = new Parser();
+        $this->assertEquals(array(), $parser->push("Asterisk Call Manager/1.3\r\n"));
+
+        $ret = $parser->push("Response: Follows\r\n--END COMMAND--\r\n\r\n");
+        $this->assertCount(1, $ret);
+
+        $first = reset($ret);
+        /* @var $first Clue\React\Ami\Protocol\Response */
+
+        $this->assertInstanceOf('Clue\React\Ami\Protocol\Response', $first);
+        $this->assertEquals('Follows', $first->getPart('Response'));
+        $this->assertEquals("--END COMMAND--", $first->getPart('_'));
+    }
+
+    public function testParsingResponseIsNotCommandResponse()
+    {
+        $parser = new Parser();
+        $this->assertEquals(array(), $parser->push("Asterisk Call Manager/1.3\r\n"));
+
+        $ret = $parser->push("Response: Success\r\nMessage: Some message--END COMMAND--\r\n\r\n");
+        $this->assertCount(1, $ret);
+
+        $first = reset($ret);
+        /* @var $first Clue\React\Ami\Protocol\Response */
+
+        $this->assertInstanceOf('Clue\React\Ami\Protocol\Response', $first);
+        $this->assertEquals('Success', $first->getPart('Response'));
+        $this->assertEquals('Some message--END COMMAND--', $first->getPart('Message'));
+    }
+
     /**
      * @expectedException UnexpectedValueException
      */


### PR DESCRIPTION
Also make preceding linefeed optional
