### PR TITLE
Require a single space after colon and preserve whitespace otherwise

### DIFF
--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -46,11 +46,11 @@ class Parser
                 $key = '_';
                 $value = $line;
             } else {
-                $pos = strpos($line, ':');
+                $pos = strpos($line, ': ');
                 if ($pos === false) {
                     throw new \UnexpectedValueException('Parse error, no colon in line "' . $line . '" found');
                 }
-                $value = ltrim(substr($line, $pos + 1));
+                $value = substr($line, $pos + 2);
                 $key = substr($line, 0, $pos);
             }
 

--- a/tests/Protocol/ParserTest.php
+++ b/tests/Protocol/ParserTest.php
@@ -19,6 +19,21 @@ class ParserTest extends TestCase
         $this->assertEquals('Success', $first->getPart('Response'));
     }
 
+    public function testParseResponseSpace()
+    {
+        $parser = new Parser();
+        $this->assertEquals(array(), $parser->push("Asterisk Call Manager/1.3\r\n"));
+
+        $ret = $parser->push("Response: Success\r\nMessage:  spaces  \r\n\r\n");
+        $this->assertCount(1, $ret);
+
+        $first = reset($ret);
+        /* @var $first Clue\React\Ami\Protocol\Response */
+
+        $this->assertInstanceOf('Clue\React\Ami\Protocol\Response', $first);
+        $this->assertEquals(' spaces  ', $first->getPart('Message'));
+    }
+
     public function testParsingMultipleEvents()
     {
         $parser = new Parser();
@@ -59,5 +74,16 @@ class ParserTest extends TestCase
         $this->assertEquals(array(), $parser->push("Asterisk Call Manager/1.3\r\n"));
 
         $parser->push("invalid response\r\n\r\n");
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     */
+    public function testParsingInvalidResponseNoSpaceAfterColonFails()
+    {
+        $parser = new Parser();
+        $this->assertEquals(array(), $parser->push("Asterisk Call Manager/1.3\r\n"));
+
+        $parser->push("Response:NoSpace\r\n\r\n");
     }
 }


### PR DESCRIPTION
See AMI v2 Specification for details:
https://wiki.asterisk.org/wiki/display/AST/AMI+v2+Specification#AMIv2Specification-MessageLayout
