### PR TITLE
UnexpectedValueExceptionParse error, no colon in line "ReportBlock:" found

### DIFF
--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -52,10 +52,16 @@ class Parser
             } else {
                 $pos = strpos($line, ': ');
                 if ($pos === false) {
-                    throw new \UnexpectedValueException('Parse error, no colon in line "' . $line . '" found');
+                    if (substr($line, -1, 1) == ':') {
+                        $key = substr($line, 0, -1);
+                        $value = "";
+                    } else {
+                        throw new \UnexpectedValueException('Parse error, no colon in line "' . $line . '" found');
+                    }
+                } else {
+                    $value = substr($line, $pos + 2);
+                    $key = substr($line, 0, $pos);
                 }
-                $value = substr($line, $pos + 2);
-                $key = substr($line, 0, $pos);
             }
 
             if (isset($fields[$key])) {

--- a/tests/Protocol/ParserTest.php
+++ b/tests/Protocol/ParserTest.php
@@ -134,4 +134,12 @@ class ParserTest extends TestCase
 
         $parser->push("Response:NoSpace\r\n\r\n");
     }
+
+    public function testParsingEmptyValue()
+    {
+        $parser = new Parser();
+        $this->assertEquals(array(), $parser->push("Asterisk Call Manager/1.3\r\n"));
+
+        $parser->push("Response:\r\n\r\n");
+    }
 }


### PR DESCRIPTION
Fixes:
```
UnexpectedValueExceptionParse error, no colon in line "ReportBlock:" found
In vendor/clue/ami-react/src/Protocol/Parser.php at line 55
Connection closed
```

When receiving (| is newline):
```
# ngrep -tqW byline -P '|' -d lo '' port 5038
interface: lo (127.0.0.0/255.0.0.0)
filter: (ip or ip6) and ( port 5038 )

T 2016/03/09 12:23:26.957583 127.0.0.1:5038 -> 127.0.0.1:38165 [AP]
Event: RTCPSent|
Privilege: reporting,all|
To: x.x.x.x:yyyy|
OurSSRC: 2070743128|
SentNTP: 1457522606.3921813504|
SentRTP: 7119840|
SentPackets: 44499|
SentOctets: 7119840|
ReportBlock:|
FractionLost: 0|
CumulativeLoss: 0|
IAJitter: 0.0003|
TheirLastSR: 2251224312|
DLSR: 0.0000 (sec)|
|
```

Asterisk version: 1.8.32.3