### PR TITLE
Support parsing messages with missing space after colon

### DIFF
--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -50,18 +50,13 @@ class Parser
                 $key = Response::FIELD_COMMAND_OUTPUT;
                 $value = $line;
             } else {
-                $pos = strpos($line, ': ');
+                $pos = strpos($line, ':');
                 if ($pos === false) {
-                    if (substr($line, -1, 1) == ':') {
-                        $key = substr($line, 0, -1);
-                        $value = "";
-                    } else {
-                        throw new \UnexpectedValueException('Parse error, no colon in line "' . $line . '" found');
-                    }
-                } else {
-                    $value = substr($line, $pos + 2);
-                    $key = substr($line, 0, $pos);
+                    throw new \UnexpectedValueException('Parse error, no colon in line "' . $line . '" found');
                 }
+
+                $value = (string)substr($line, $pos + (isset($line[$pos + 1]) && $line[$pos + 1] === ' ' ? 2 : 1));
+                $key = substr($line, 0, $pos);
             }
 
             if (isset($fields[$key])) {

--- a/src/Protocol/Parser.php
+++ b/src/Protocol/Parser.php
@@ -52,10 +52,16 @@ class Parser
             } else {
                 $pos = strpos($line, ': ');
                 if ($pos === false) {
-                    throw new \UnexpectedValueException('Parse error, no colon in line "' . $line . '" found');
+                    if (substr($line, -1, 1) == ':') {
+                        $key = substr($line, 0, -1);
+                        $value = "";
+                    } else {
+                        throw new \UnexpectedValueException('Parse error, no colon in line "' . $line . '" found');
+                    }
+                } else {
+                    $value = substr($line, $pos + 2);
+                    $key = substr($line, 0, $pos);
                 }
-                $value = substr($line, $pos + 2);
-                $key = substr($line, 0, $pos);
             }
 
             if (isset($fields[$key])) {

--- a/tests/Protocol/ParserTest.php
+++ b/tests/Protocol/ParserTest.php
@@ -124,22 +124,33 @@ class ParserTest extends TestCase
         $parser->push("invalid response\r\n\r\n");
     }
 
-    /**
-     * @expectedException UnexpectedValueException
-     */
-    public function testParsingInvalidResponseNoSpaceAfterColonFails()
+    public function testParsingMissingSpaceWithValue()
     {
         $parser = new Parser();
         $this->assertEquals(array(), $parser->push("Asterisk Call Manager/1.3\r\n"));
 
-        $parser->push("Response:NoSpace\r\n\r\n");
+        $ret = $parser->push("Response:NoSpace\r\n\r\n");
+        $this->assertCount(1, $ret);
+
+        $first = reset($ret);
+        /* @var $first Clue\React\Ami\Protocol\Response */
+
+        $this->assertInstanceOf('Clue\React\Ami\Protocol\Response', $first);
+        $this->assertEquals('NoSpace', $first->getFieldValue('Response'));
     }
 
-    public function testParsingEmptyValue()
+    public function testParsingMissingSpaceEmptyValue()
     {
         $parser = new Parser();
         $this->assertEquals(array(), $parser->push("Asterisk Call Manager/1.3\r\n"));
 
-        $parser->push("Response:\r\n\r\n");
+        $ret = $parser->push("Response:\r\n\r\n");
+        $this->assertCount(1, $ret);
+
+        $first = reset($ret);
+        /* @var $first Clue\React\Ami\Protocol\Response */
+
+        $this->assertInstanceOf('Clue\React\Ami\Protocol\Response', $first);
+        $this->assertEquals('', $first->getFieldValue('Response'));
     }
 }

--- a/tests/Protocol/ParserTest.php
+++ b/tests/Protocol/ParserTest.php
@@ -134,4 +134,12 @@ class ParserTest extends TestCase
 
         $parser->push("Response:NoSpace\r\n\r\n");
     }
+
+    public function testParsingEmptyValue()
+    {
+        $parser = new Parser();
+        $this->assertEquals(array(), $parser->push("Asterisk Call Manager/1.3\r\n"));
+
+        $parser->push("Response:\r\n\r\n");
+    }
 }


### PR DESCRIPTION
This makes the parser more robust to some malformed legacy messages, such as in #28.

This builds on top of #28.