### PR TITLE
Fix HHVM build for now again and ignore future HHVM build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,14 @@ language: php
 php:
   - 5.3
   - 5.6
-  - hhvm
+
+# also test against HHVM, but require "trusty" and ignore errors
+matrix:
+  include:
+    - php: hhvm
+      dist: trusty
+  allow_failures:
+    - php: hhvm
 
 env:
   - LOGIN=username:password@localhost


### PR DESCRIPTION
The HHVM build reports an error once again. Let's fix this once again by updating the base distro from precise to trusty and ignore any future HHVM build errors.

See travis-ci/travis-ci#7712 (comment)
Originally from clue/php-http-proxy-react#12